### PR TITLE
Windowsの画面拡大率が100%以外の場合に画像認識ができないバグを修正

### DIFF
--- a/autoStartMarginTimer/autoStartMarginTimer.vcxproj
+++ b/autoStartMarginTimer/autoStartMarginTimer.vcxproj
@@ -149,6 +149,9 @@
       <TypeLibraryName>$(IntDir)/autoStartMarginTimer.tlb</TypeLibraryName>
       <DllDataFileName />
     </Midl>
+    <Manifest>
+      <EnableDpiAwareness>PerMonitorHighDPIAware</EnableDpiAwareness>
+    </Manifest>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
@@ -222,6 +225,9 @@
       <TypeLibraryName>$(IntDir)/autoStartMarginTimer.tlb</TypeLibraryName>
       <DllDataFileName />
     </Midl>
+    <Manifest>
+      <EnableDpiAwareness>PerMonitorHighDPIAware</EnableDpiAwareness>
+    </Manifest>
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="AboutDlg.cpp" />


### PR DESCRIPTION
Closes: #1