### PR TITLE
OBS 31.1.xでマージンタイマーが正常に動作しないバグを修正

### DIFF
--- a/autoStartMarginTimer/TimerStarter.cpp
+++ b/autoStartMarginTimer/TimerStarter.cpp
@@ -94,7 +94,7 @@ BOOL CALLBACK EnumWindowsProc(HWND hwnd, LPARAM lparam) {
       if (!starter->ObsRecognized()) {
         // ウィンドウプロジェクター
         for (const wchar_t* prefix : OBS_WINDOW_PROJECTOR_PREFIX) {
-          if (StrCmpN(window_name.get(), prefix, lstrlen(prefix))) {
+          if (StrCmpN(window_name.get(), prefix, lstrlen(prefix)) == 0) {
             starter->SetObsPreviewHWND(hwnd);
             // FALSEを返さないのは、対話ウィンドウが未調査の可能性があるため
             return TRUE;

--- a/autoStartMarginTimer/TimerStarter.cpp
+++ b/autoStartMarginTimer/TimerStarter.cpp
@@ -61,8 +61,9 @@ DWORD FindOBSProcess() {
 BOOL CALLBACK EnumWindowsProc(HWND hwnd, LPARAM lparam) {
   const int CLASS_NAME_LENGTH = 256;
   const wchar_t OBS_WINDOW_CLASS_NAME_POSTFIX[] = L"QWindowIcon";
-  const wchar_t OBS_PREVIEW_PREFIX[] = L"ウィンドウ プロジェクター (ソース) - ";
-  const wchar_t OBS_PREVIEW_PREFIX_2[] = L"ウィンドウプロジェクター (ソース) - ";
+  const wchar_t OBS_WINDOW_PROJECTOR_PREFIX[][24] = {
+      L"ウィンドウ プロジェクター (ソース) - ",
+      L"ウィンドウプロジェクター (ソース) - ", L"プロジェクター - ソース:"};
   const wchar_t OBS_INTERACTIVE[] = L"'MarginTimer' との相互作用";
 
   TimerStarter* starter = reinterpret_cast<TimerStarter*>(lparam);
@@ -92,17 +93,13 @@ BOOL CALLBACK EnumWindowsProc(HWND hwnd, LPARAM lparam) {
         !(style & WS_DISABLED)) {
       if (!starter->ObsRecognized()) {
         // ウィンドウプロジェクター
-        if (StrCmpN(window_name.get(), OBS_PREVIEW_PREFIX,
-                    _countof(OBS_PREVIEW_PREFIX) - 1) == 0) {
-          starter->SetObsPreviewHWND(hwnd);
-          // FALSEを返さないのは、対話ウィンドウが未調査の可能性があるため
-          return TRUE;
-        } else if (StrCmpN(window_name.get(), OBS_PREVIEW_PREFIX_2,
-                           _countof(OBS_PREVIEW_PREFIX_2) - 1) == 0) {
-          starter->SetObsPreviewHWND(hwnd);
-          // FALSEを返さないのは、対話ウィンドウが未調査の可能性があるため
-          return TRUE;
-        }
+        for (const wchar_t* prefix : OBS_WINDOW_PROJECTOR_PREFIX) {
+          if (StrCmpN(window_name.get(), prefix, lstrlen(prefix))) {
+            starter->SetObsPreviewHWND(hwnd);
+            // FALSEを返さないのは、対話ウィンドウが未調査の可能性があるため
+            return TRUE;
+          }
+        };
       }
       // ブラウザとの対話ウィンドウ
       if (lstrcmp(window_name.get(), OBS_INTERACTIVE) == 0) {


### PR DESCRIPTION
OBS 31.1.xでマージンタイマーが正常に動作しないバグを修正
#19